### PR TITLE
compile ex3 and use it to load executable at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
+loader
 main
 .vscode/

--- a/test.sh
+++ b/test.sh
@@ -13,3 +13,13 @@ echo
 echo "type Z to end example 2. use 'stty cbreak' in your terminal to avoid requiring newlines each character"
 rm -f out && bash ./super_crapsm.sh ex2.asm out && ./main out 
 echo
+
+
+# compile ex3.asm (a binary loader)
+echo "compiling loader"
+bash ./super_crapsm.sh ex3.asm loader
+# send a small program to display a single character into the loader
+# first byte is length, followed by the data
+echo "loading 7 byte program: LOAD 00 05  STORE FF FF  DB AA\n"
+echo -ne \\x07\\x08\\x00\\x05\\x09\\xff\\xff\\xaa | ./main loader
+echo


### PR DESCRIPTION
This example compiles a simple bootloader that takes a single byte of the number of bytes to accept, then accepts those bytes and puts them in memory address 0x100. Finally it jumps to 0x100. `test.sh` then runs this bootloader with the simulator and loads a very simple program that reads a byte from memory and prints it.

With this, we're getting closer to a physically-realizable useful design. The bootloader would be the only program 'stored' on the machine, with further code being transferred from a host machine. At least, that's how it'd work during development. Once some type of non-volatile peripheral storage is created, the bootloader could be changed to load from that.

It's worth noting that the bootloader code is short enough that it could be toggled into the machine with a programmer's panel, as was done with many machines in the 60s and 70s.